### PR TITLE
-downgrades typescript version to 2.7.2, solving build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rxjs-compat": "^6.3.3",
     "rxjs-tslint": "^0.1.5",
     "sass-loader": "6.0.3",
-    "typescript": "2.9.2",
+    "typescript": "2.7.2",
     "webpack": "2.4.1",
     "webpack-dev-server": "2.4.5",
     "zone.js": "0.8.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,10 +3741,10 @@ type-is@~1.6.14:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
 
 uglify-js@^2.8.5, uglify-js@~2.8.22:
   version "2.8.22"


### PR DESCRIPTION
Ported change from https://github.com/L96Github/ngx-errors/commit/8a14184d0e9826d29d6ad0201360a440a50ef4b2